### PR TITLE
cSettings in SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "TOFileSystemObserver",
+            type: .dynamic,
             targets: ["TOFileSystemObserver"]),
     ],
     dependencies: [ ],
@@ -19,7 +20,8 @@ let package = Package(
         .target(
             name: "TOFileSystemObserver",
             dependencies: [],
-            path: "TOFileSystemObserver"
+            path: "TOFileSystemObserver",
+            cSettings: [.define("TARGET_OS_OSX", .when(platforms: [.macOS]))]
         ),
     ]
 )


### PR DESCRIPTION
Apparently swift targets do not provide this flag to their packages correctly, so I had to define it in the Package itself. Otherwise categories for NSIndexPath are not being found at runtime and mac app crashes 😒